### PR TITLE
fix(build): prevent prerender crash on /dev/ui

### DIFF
--- a/src/app/dev/ui/ClientPage.tsx
+++ b/src/app/dev/ui/ClientPage.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+export default function UiPage() {
+  return (
+    <div className="space-y-6 p-8">
+      <div className="space-x-2">
+        <Button size="sm">Primary</Button>
+        <Button variant="outline" size="sm">
+          Outline
+        </Button>
+        <Button variant="ghost" size="sm">
+          Ghost
+        </Button>
+        <Button size="sm" disabled>
+          Disabled
+        </Button>
+        <Button size="sm" isLoading>
+          Loading
+        </Button>
+      </div>
+      <div className="space-x-2">
+        <Button>Primary</Button>
+        <Button variant="outline">Outline</Button>
+        <Button variant="ghost">Ghost</Button>
+        <Button disabled>Disabled</Button>
+        <Button isLoading>Loading</Button>
+      </div>
+      <div className="space-x-2">
+        <Button size="lg">Primary</Button>
+        <Button variant="outline" size="lg">
+          Outline
+        </Button>
+        <Button variant="ghost" size="lg">
+          Ghost
+        </Button>
+        <Button size="lg" disabled>
+          Disabled
+        </Button>
+        <Button size="lg" isLoading>
+          Loading
+        </Button>
+      </div>
+      <div className="space-x-2">
+        <Button asChild>
+          <a href="#">As Link</a>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dev/ui/page.tsx
+++ b/src/app/dev/ui/page.tsx
@@ -1,50 +1,8 @@
-import { Button } from "@/components/ui/button";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
 
-export default function UiPage() {
-  return (
-    <div className="space-y-6 p-8">
-      <div className="space-x-2">
-        <Button size="sm">Primary</Button>
-        <Button variant="outline" size="sm">
-          Outline
-        </Button>
-        <Button variant="ghost" size="sm">
-          Ghost
-        </Button>
-        <Button size="sm" disabled>
-          Disabled
-        </Button>
-        <Button size="sm" isLoading>
-          Loading
-        </Button>
-      </div>
-      <div className="space-x-2">
-        <Button>Primary</Button>
-        <Button variant="outline">Outline</Button>
-        <Button variant="ghost">Ghost</Button>
-        <Button disabled>Disabled</Button>
-        <Button isLoading>Loading</Button>
-      </div>
-      <div className="space-x-2">
-        <Button size="lg">Primary</Button>
-        <Button variant="outline" size="lg">
-          Outline
-        </Button>
-        <Button variant="ghost" size="lg">
-          Ghost
-        </Button>
-        <Button size="lg" disabled>
-          Disabled
-        </Button>
-        <Button size="lg" isLoading>
-          Loading
-        </Button>
-      </div>
-      <div className="space-x-2">
-        <Button asChild>
-          <a href="#">As Link</a>
-        </Button>
-      </div>
-    </div>
-  );
+import ClientPage from "./ClientPage";
+
+export default function Page() {
+  return <ClientPage />;
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 


### PR DESCRIPTION
## Summary
- prevent static build errors for /dev/ui by forcing dynamic rendering
- mark UI components as client-side to enable interactivity

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0837f7f60832f99b5d6b1885729fc