### PR TITLE
feat(www): home hero + services

### DIFF
--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -1,12 +1,11 @@
+import Hero from "@/components/marketing/hero";
+import Services from "@/components/marketing/services";
+
 export default function HomePage() {
   return (
-    <section className="flex flex-col items-center justify-center py-24 text-center">
-      <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-6">
-        MTD Software&apos;a Hoş Geldiniz
-      </h1>
-      <p className="text-lg sm:text-xl max-w-2xl">
-        Modern çözümlerle işinizi büyütün.
-      </p>
-    </section>
+    <>
+      <Hero />
+      <Services />
+    </>
   );
 }

--- a/src/components/marketing/hero.tsx
+++ b/src/components/marketing/hero.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+
+export default function Hero() {
+  return (
+    <section className="py-24">
+      <div className="container max-w-5xl mx-auto text-center flex flex-col items-center gap-6">
+        <h1 className="text-4xl md:text-5xl font-bold">
+          SaaS &amp; Danışmanlık ile daha hızlı ürünleşin
+        </h1>
+        <p className="text-lg text-muted-foreground max-w-2xl">
+          Modern SaaS çözümleri ve uzman danışmanlıkla fikirlerinizi hızla piyasaya sunun.
+        </p>
+        <div className="flex flex-col sm:flex-row gap-4 mt-4">
+          <Link
+            href="/iletisim"
+            className="inline-flex items-center justify-center px-6 py-3.5 rounded-md bg-primary text-white font-medium"
+          >
+            Teklif Al
+          </Link>
+          <Link
+            href="/hizmetler"
+            className="inline-flex items-center justify-center px-6 py-3.5 rounded-md border border-foreground/20"
+          >
+            Hizmetler
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/marketing/services.tsx
+++ b/src/components/marketing/services.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link";
+
+const services = [
+  {
+    title: "SaaS Geliştirme",
+    description:
+      "İhtiyaçlarınıza özel ölçeklenebilir SaaS uygulamaları tasarlayıp geliştiriyoruz.",
+    href: "/hizmetler#saas-gelistirme",
+  },
+  {
+    title: "Kurumsal Danışmanlık",
+    description:
+      "Dijital dönüşüm ve süreç iyileştirme için deneyimli ekibimizle yanınızdayız.",
+    href: "/hizmetler#kurumsal-danismanlik",
+  },
+  {
+    title: "Bulut & DevOps",
+    description:
+      "Bulut altyapısı ve otomasyonla hızlı, güvenilir dağıtımlar sağlayın.",
+    href: "/hizmetler#bulut-devops",
+  },
+];
+
+export default function Services() {
+  return (
+    <section className="py-24">
+      <div className="container max-w-5xl mx-auto text-center">
+        <h2 className="text-3xl font-bold mb-12">Hizmetlerimiz</h2>
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {services.map((service) => (
+            <div
+              key={service.title}
+              className="p-6 rounded-lg bg-muted text-left flex flex-col"
+            >
+              <h3 className="text-xl font-semibold mb-2">{service.title}</h3>
+              <p className="text-sm text-muted-foreground flex-1">
+                {service.description}
+              </p>
+              <Link
+                href={service.href}
+                className="mt-4 text-primary hover:underline self-start"
+              >
+                Detaylar
+              </Link>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add hero section with headline, supporting copy and CTAs
- list three core services in responsive cards

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b086d2fa30832fa41c1077541d7f0e