### PR TITLE
Add marketing page skeletons with breadcrumbs

### DIFF
--- a/src/app/(marketing)/hakkimizda/page.tsx
+++ b/src/app/(marketing)/hakkimizda/page.tsx
@@ -1,8 +1,41 @@
+import Breadcrumbs from "@/components/breadcrumbs";
+
 export default function HakkimizdaPage() {
   return (
     <section className="p-8">
-      <h1 className="text-2xl font-semibold mb-4">Hakkımızda</h1>
-      <p>Şirketimiz hakkında bilgiler yakında burada.</p>
+      <div className="max-w-5xl mx-auto space-y-8">
+        <Breadcrumbs
+          items={[
+            { label: "Anasayfa", href: "/" },
+            { label: "Hakkımızda" },
+          ]}
+        />
+        <h1 className="text-3xl font-bold">Hakkımızda</h1>
+
+        <section className="space-y-4">
+          <h2 className="text-2xl font-semibold">Kısa Hikâye</h2>
+          <p>Şirketin kuruluş hikâyesi ve gelişimi burada yer alacak.</p>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-2xl font-semibold">Değerlerimiz</h2>
+          <ul className="list-disc list-inside space-y-1">
+            <li>Değer örneği 1</li>
+            <li>Değer örneği 2</li>
+            <li>Değer örneği 3</li>
+          </ul>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-2xl font-semibold">Çalışma Biçimimiz</h2>
+          <ul className="list-disc list-inside space-y-1">
+            <li>Çalışma maddesi 1</li>
+            <li>Çalışma maddesi 2</li>
+            <li>Çalışma maddesi 3</li>
+          </ul>
+        </section>
+      </div>
     </section>
   );
 }
+

--- a/src/app/(marketing)/hizmetler/page.tsx
+++ b/src/app/(marketing)/hizmetler/page.tsx
@@ -1,8 +1,84 @@
+import Breadcrumbs from "@/components/breadcrumbs";
+
 export default function HizmetlerPage() {
   return (
     <section className="p-8">
-      <h1 className="text-2xl font-semibold mb-4">Hizmetler</h1>
-      <p>Sunulan hizmetler yakında burada.</p>
+      <div className="max-w-5xl mx-auto space-y-8">
+        <Breadcrumbs
+          items={[
+            { label: "Anasayfa", href: "/" },
+            { label: "Hizmetler" },
+          ]}
+        />
+        <h1 className="text-3xl font-bold">Hizmetler</h1>
+
+        <section className="space-y-6">
+          <h2 className="text-2xl font-semibold">SaaS Geliştirme</h2>
+          <div className="space-y-4">
+            <div>
+              <h3 className="text-xl font-medium">Kapsam</h3>
+              <p>Proje gereksinimleri ve hedefleri burada özetlenecek.</p>
+            </div>
+            <div>
+              <h3 className="text-xl font-medium">Teslimatlar</h3>
+              <p>Bu hizmet kapsamında sunulacak çıktıların listesi.</p>
+            </div>
+            <div>
+              <h3 className="text-xl font-medium">Süre &amp; Yaklaşım</h3>
+              <p>Zaman çizelgesi ve çalışma metodolojisi açıklaması.</p>
+            </div>
+            <div>
+              <h3 className="text-xl font-medium">Teknik Stack Örnekleri</h3>
+              <p>Kullanılabilecek teknolojilere örnekler.</p>
+            </div>
+          </div>
+        </section>
+
+        <section className="space-y-6">
+          <h2 className="text-2xl font-semibold">Teknik Danışmanlık</h2>
+          <div className="space-y-4">
+            <div>
+              <h3 className="text-xl font-medium">Kapsam</h3>
+              <p>Danışmanlık alanlarının genel çerçevesi.</p>
+            </div>
+            <div>
+              <h3 className="text-xl font-medium">Teslimatlar</h3>
+              <p>Raporlar, öneriler ve diğer çıktılar.</p>
+            </div>
+            <div>
+              <h3 className="text-xl font-medium">Süre &amp; Yaklaşım</h3>
+              <p>İş birlik süresi ve izlenen yöntemler.</p>
+            </div>
+            <div>
+              <h3 className="text-xl font-medium">Teknik Stack Örnekleri</h3>
+              <p>Önerilen araç ve teknolojiler.</p>
+            </div>
+          </div>
+        </section>
+
+        <section className="space-y-6">
+          <h2 className="text-2xl font-semibold">Ürün Tasarımı</h2>
+          <div className="space-y-4">
+            <div>
+              <h3 className="text-xl font-medium">Kapsam</h3>
+              <p>Tasarım sürecinin aşamaları ve hedefleri.</p>
+            </div>
+            <div>
+              <h3 className="text-xl font-medium">Teslimatlar</h3>
+              <p>Wireframe, prototip ve diğer görsel çıktılar.</p>
+            </div>
+            <div>
+              <h3 className="text-xl font-medium">Süre &amp; Yaklaşım</h3>
+              <p>Proje süresi ve kullanılacak yöntem.</p>
+            </div>
+            <div>
+              <h3 className="text-xl font-medium">Teknik Stack Örnekleri</h3>
+              <p>Tasarım araçları ve teknolojilerine örnekler.</p>
+            </div>
+          </div>
+        </section>
+      </div>
     </section>
   );
 }
+

--- a/src/components/breadcrumbs.tsx
+++ b/src/components/breadcrumbs.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+
+interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+export default function Breadcrumbs({ items }: { items: BreadcrumbItem[] }) {
+  return (
+    <nav aria-label="breadcrumb" className="text-sm mb-6">
+      <ol className="flex flex-wrap gap-1 items-center text-muted-foreground">
+        {items.map((item, idx) => {
+          const isLast = idx === items.length - 1;
+          return (
+            <li key={idx} className="flex items-center gap-1">
+              {item.href && !isLast ? (
+                <Link href={item.href} className="hover:underline">
+                  {item.label}
+                </Link>
+              ) : (
+                <span>{item.label}</span>
+              )}
+              {!isLast && <span className="text-foreground/40">/</span>}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add breadcrumb navigation component
- scaffold "Hakkımızda" page with story, values and workflow placeholders
- scaffold "Hizmetler" page with service blocks and sub-sections

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b0883321dc832f8b3f2fc778f32db2