### PR TITLE
Add SEO metadata and sitemap generation

### DIFF
--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -1,5 +1,26 @@
+import type { Metadata } from "next";
 import Hero from "@/components/marketing/hero";
 import Services from "@/components/marketing/services";
+
+export const metadata: Metadata = {
+  title: "Anasayfa",
+  openGraph: {
+    title: "Anasayfa",
+    images: [
+      {
+        url: "/og?title=MTD%20Software&subtitle=Anasayfa",
+        width: 1200,
+        height: 630,
+        alt: "MTD Software",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Anasayfa",
+    images: ["/og?title=MTD%20Software&subtitle=Anasayfa"],
+  },
+};
 
 export default function HomePage() {
   return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,39 @@
 import type { Metadata } from "next";
 import "./globals.css";
 
+const siteUrl = "https://mtdsoftware.com";
+
 export const metadata: Metadata = {
-  title: "MTD Software",
+  metadataBase: new URL(siteUrl),
+  title: {
+    default: "MTD Software",
+    template: "%s | MTD Software",
+  },
   description: "MTD Software resmi sitesi",
+  openGraph: {
+    title: "MTD Software",
+    description: "MTD Software resmi sitesi",
+    url: siteUrl,
+    siteName: "MTD Software",
+    images: [
+      {
+        url: "/og?title=MTD%20Software&subtitle=MTD%20Software%20resmi%20sitesi",
+        width: 1200,
+        height: 630,
+        alt: "MTD Software",
+      },
+    ],
+    locale: "tr_TR",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "MTD Software",
+    description: "MTD Software resmi sitesi",
+    images: [
+      "/og?title=MTD%20Software&subtitle=MTD%20Software%20resmi%20sitesi",
+    ],
+  },
 };
 
 export default function RootLayout({

--- a/src/app/og/route.tsx
+++ b/src/app/og/route.tsx
@@ -1,0 +1,34 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const title = searchParams.get("title") ?? "MTD Software";
+  const subtitle = searchParams.get("subtitle") ?? "";
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: "flex",
+          height: "100%",
+          width: "100%",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: "#fff",
+          fontFamily: "sans-serif",
+          fontSize: 64,
+        }}
+      >
+        <div style={{ fontWeight: "bold" }}>{title}</div>
+        {subtitle && <div style={{ fontSize: 32 }}>{subtitle}</div>}
+      </div>
+    ),
+    {
+      width: 1200,
+      height: 630,
+    }
+  );
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,15 @@
+import { MetadataRoute } from "next";
+
+const baseUrl = "https://mtdsoftware.com";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+      },
+    ],
+    sitemap: `${baseUrl}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,24 @@
+import { MetadataRoute } from "next";
+
+const baseUrl = "https://mtdsoftware.com";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+    },
+    {
+      url: `${baseUrl}/hakkimizda`,
+      lastModified: new Date(),
+    },
+    {
+      url: `${baseUrl}/hizmetler`,
+      lastModified: new Date(),
+    },
+    {
+      url: `${baseUrl}/iletisim`,
+      lastModified: new Date(),
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- add default SEO metadata with Open Graph and Twitter tags
- serve dynamic OG images for social sharing
- provide sitemap and robots configuration

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module 'nodemailer' or '@radix-ui/react-slot')*

------
https://chatgpt.com/codex/tasks/task_e_68b08bce61b0832fab99efbe26c751cd