### PR TITLE
Add placeholder legal pages and footer links

### DIFF
--- a/src/app/(legal)/gizlilik/page.tsx
+++ b/src/app/(legal)/gizlilik/page.tsx
@@ -1,0 +1,70 @@
+import Breadcrumbs from "@/components/breadcrumbs";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Gizlilik Politikası",
+  description: "MTD Software gizlilik politikası",
+  robots: {
+    index: true,
+    follow: true,
+  },
+};
+
+export default function GizlilikPage() {
+  const lastUpdated = new Date().toLocaleDateString("tr-TR", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+
+  return (
+    <section className="p-8">
+      <div className="max-w-5xl mx-auto space-y-8">
+        <Breadcrumbs
+          items={[
+            { label: "Anasayfa", href: "/" },
+            { label: "Gizlilik Politikası" },
+          ]}
+        />
+        <h1 className="text-3xl font-bold">Gizlilik Politikası</h1>
+        <p className="text-sm text-muted-foreground">Son güncelleme: {lastUpdated}</p>
+
+        <nav aria-label="İçindekiler" className="space-y-2">
+          <h2 className="text-2xl font-semibold">İçindekiler</h2>
+          <ol className="list-decimal list-inside space-y-1">
+            <li>
+              <a href="#toplanan-bilgiler" className="hover:underline">
+                Toplanan Bilgiler
+              </a>
+            </li>
+            <li>
+              <a href="#bilgilerin-kullanimi" className="hover:underline">
+                Bilgilerin Kullanımı
+              </a>
+            </li>
+            <li>
+              <a href="#bilgi-guvenligi" className="hover:underline">
+                Bilgi Güvenliği
+              </a>
+            </li>
+          </ol>
+        </nav>
+
+        <section id="toplanan-bilgiler" className="space-y-4">
+          <h2 className="text-2xl font-semibold">Toplanan Bilgiler</h2>
+          <p>İçerik buraya gelecek.</p>
+        </section>
+
+        <section id="bilgilerin-kullanimi" className="space-y-4">
+          <h2 className="text-2xl font-semibold">Bilgilerin Kullanımı</h2>
+          <p>İçerik buraya gelecek.</p>
+        </section>
+
+        <section id="bilgi-guvenligi" className="space-y-4">
+          <h2 className="text-2xl font-semibold">Bilgi Güvenliği</h2>
+          <p>İçerik buraya gelecek.</p>
+        </section>
+      </div>
+    </section>
+  );
+}

--- a/src/app/(legal)/kullanim-sartlari/page.tsx
+++ b/src/app/(legal)/kullanim-sartlari/page.tsx
@@ -1,0 +1,70 @@
+import Breadcrumbs from "@/components/breadcrumbs";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Kullanım Şartları",
+  description: "MTD Software kullanım şartları",
+  robots: {
+    index: true,
+    follow: true,
+  },
+};
+
+export default function KullanimSartlariPage() {
+  const lastUpdated = new Date().toLocaleDateString("tr-TR", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+
+  return (
+    <section className="p-8">
+      <div className="max-w-5xl mx-auto space-y-8">
+        <Breadcrumbs
+          items={[
+            { label: "Anasayfa", href: "/" },
+            { label: "Kullanım Şartları" },
+          ]}
+        />
+        <h1 className="text-3xl font-bold">Kullanım Şartları</h1>
+        <p className="text-sm text-muted-foreground">Son güncelleme: {lastUpdated}</p>
+
+        <nav aria-label="İçindekiler" className="space-y-2">
+          <h2 className="text-2xl font-semibold">İçindekiler</h2>
+          <ol className="list-decimal list-inside space-y-1">
+            <li>
+              <a href="#kabul" className="hover:underline">
+                Kabul ve Şartlar
+              </a>
+            </li>
+            <li>
+              <a href="#hizmet-kosullari" className="hover:underline">
+                Hizmet Koşulları
+              </a>
+            </li>
+            <li>
+              <a href="#sorumluluk" className="hover:underline">
+                Sorumluluk Reddi
+              </a>
+            </li>
+          </ol>
+        </nav>
+
+        <section id="kabul" className="space-y-4">
+          <h2 className="text-2xl font-semibold">Kabul ve Şartlar</h2>
+          <p>İçerik buraya gelecek.</p>
+        </section>
+
+        <section id="hizmet-kosullari" className="space-y-4">
+          <h2 className="text-2xl font-semibold">Hizmet Koşulları</h2>
+          <p>İçerik buraya gelecek.</p>
+        </section>
+
+        <section id="sorumluluk" className="space-y-4">
+          <h2 className="text-2xl font-semibold">Sorumluluk Reddi</h2>
+          <p>İçerik buraya gelecek.</p>
+        </section>
+      </div>
+    </section>
+  );
+}

--- a/src/app/(legal)/kvkk/page.tsx
+++ b/src/app/(legal)/kvkk/page.tsx
@@ -1,0 +1,70 @@
+import Breadcrumbs from "@/components/breadcrumbs";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "KVKK",
+  description: "MTD Software KVKK aydınlatma metni",
+  robots: {
+    index: true,
+    follow: true,
+  },
+};
+
+export default function KvkkPage() {
+  const lastUpdated = new Date().toLocaleDateString("tr-TR", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+
+  return (
+    <section className="p-8">
+      <div className="max-w-5xl mx-auto space-y-8">
+        <Breadcrumbs
+          items={[
+            { label: "Anasayfa", href: "/" },
+            { label: "KVKK" },
+          ]}
+        />
+        <h1 className="text-3xl font-bold">KVKK Aydınlatma Metni</h1>
+        <p className="text-sm text-muted-foreground">Son güncelleme: {lastUpdated}</p>
+
+        <nav aria-label="İçindekiler" className="space-y-2">
+          <h2 className="text-2xl font-semibold">İçindekiler</h2>
+          <ol className="list-decimal list-inside space-y-1">
+            <li>
+              <a href="#veri-sorumlusu" className="hover:underline">
+                Veri Sorumlusu
+              </a>
+            </li>
+            <li>
+              <a href="#toplanan-veriler" className="hover:underline">
+                Toplanan Veriler
+              </a>
+            </li>
+            <li>
+              <a href="#haklariniz" className="hover:underline">
+                Haklarınız
+              </a>
+            </li>
+          </ol>
+        </nav>
+
+        <section id="veri-sorumlusu" className="space-y-4">
+          <h2 className="text-2xl font-semibold">Veri Sorumlusu</h2>
+          <p>İçerik buraya gelecek.</p>
+        </section>
+
+        <section id="toplanan-veriler" className="space-y-4">
+          <h2 className="text-2xl font-semibold">Toplanan Veriler</h2>
+          <p>İçerik buraya gelecek.</p>
+        </section>
+
+        <section id="haklariniz" className="space-y-4">
+          <h2 className="text-2xl font-semibold">Haklarınız</h2>
+          <p>İçerik buraya gelecek.</p>
+        </section>
+      </div>
+    </section>
+  );
+}

--- a/src/app/(legal)/layout.tsx
+++ b/src/app/(legal)/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+import Header from "@/components/layout/Header";
+import Footer from "@/components/layout/Footer";
+
+export default function LegalLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen flex flex-col bg-background text-foreground">
+      <Header />
+      <main className="flex-1">{children}</main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -20,5 +20,17 @@ export default function sitemap(): MetadataRoute.Sitemap {
       url: `${baseUrl}/iletisim`,
       lastModified: new Date(),
     },
+    {
+      url: `${baseUrl}/gizlilik`,
+      lastModified: new Date(),
+    },
+    {
+      url: `${baseUrl}/kvkk`,
+      lastModified: new Date(),
+    },
+    {
+      url: `${baseUrl}/kullanim-sartlari`,
+      lastModified: new Date(),
+    },
   ];
 }

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -8,17 +8,17 @@ export default function Footer() {
         <nav>
           <ul className="flex flex-col sm:flex-row gap-2 sm:gap-6">
             <li>
-              <Link href="#" className="hover:underline">
+              <Link href="/gizlilik" className="hover:underline">
                 Gizlilik
               </Link>
             </li>
             <li>
-              <Link href="#" className="hover:underline">
+              <Link href="/kvkk" className="hover:underline">
                 KVKK
               </Link>
             </li>
             <li>
-              <Link href="#" className="hover:underline">
+              <Link href="/kullanim-sartlari" className="hover:underline">
                 Kullanım Şartları
               </Link>
             </li>


### PR DESCRIPTION
## Summary
- add placeholder KVKK, Gizlilik, and Kullanım Şartları pages with update date and contents outline
- link new pages from footer and include them in sitemap

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b08f8c24dc832f9beea08e2630df4d